### PR TITLE
Python 3 compatibility changes

### DIFF
--- a/python/lsst/sims/ocs/setup/parser.py
+++ b/python/lsst/sims/ocs/setup/parser.py
@@ -24,7 +24,7 @@ def create_parser():
                         "years.")
     parser.add_argument("--no-sched", dest="no_scheduler", action="store_true",
                         help="Flag to make program not wait for Scheduler.")
-    parser.add_argument("--scheduler-timeout", dest="scheduler_timeout",
+    parser.add_argument("--scheduler-timeout", dest="scheduler_timeout", default=600, type=float,
                         help="Override the 60 second DDS message timeouts in the Scheduler main loop.")
     parser.add_argument("--profile", dest="profile", action="store_true", help="Run the profiler on SOCS and"
                         "Scheduler code.")

--- a/scripts/central_logger
+++ b/scripts/central_logger
@@ -4,7 +4,7 @@ import argparse
 import logging
 import logging.handlers
 import pickle
-import SocketServer
+import socketserver as SocketServer
 import struct
 
 from lsst.sims.ocs.setup.log import DETAIL_LEVEL, MIN_FILE


### PR DESCRIPTION
added default scheduler-timeout value of 600, and changed SocketServer import statement to its new Py3 name, socketserver (with no caps). It will still work in Python 2.7 with python-future. 