### PR TITLE
Feature/clean fieldid dep

### DIFF
--- a/python/lsst/sims/ocs/kernel/sequencer.py
+++ b/python/lsst/sims/ocs/kernel/sequencer.py
@@ -173,13 +173,12 @@ class Sequencer(object):
             slew_info, exposure_info = self.observatory_model.observe(th, target, self.observation)
             self.sky_model.update(self.observation.observation_start_time)
 
-            nid = numpy.array([target.fieldId])
             nra = numpy.radians(numpy.array([self.observation.ra]))
             ndec = numpy.radians(numpy.array([self.observation.decl]))
 
-            sky_mags = self.sky_model.get_sky_brightness(nid, extrapolate=True,
+            sky_mags = self.sky_model.get_sky_brightness(nra, ndec, extrapolate=True,
                                                          override_exclude_planets=False)
-            attrs = self.sky_model.get_target_information(nid, nra, ndec)
+            attrs = self.sky_model.get_target_information(nra, ndec)
             msi = self.sky_model.get_moon_sun_info(nra, ndec)
 
             self.observation.sky_brightness = sky_mags[self.observation.filter][0]

--- a/python/lsst/sims/ocs/kernel/simulator.py
+++ b/python/lsst/sims/ocs/kernel/simulator.py
@@ -107,7 +107,7 @@ class Simulator(object):
     def duration(self):
         """int: The duration of the simulation in days.
         """
-        return round(self.fractional_duration * DAYS_IN_YEAR)
+        return math.floor(self.fractional_duration * DAYS_IN_YEAR)
 
     def end_night(self):
         """Perform actions at the end of the night.


### PR DESCRIPTION
This PR change the way the system access the position of the fields. Instead of relying on fieldid, use coordinates. 