### PR TITLE
Update default configuration

### DIFF
--- a/python/lsst/sims/ocs/configuration/instrument/dome.py
+++ b/python/lsst/sims/ocs/configuration/instrument/dome.py
@@ -39,5 +39,5 @@ class Dome(pexConfig.Config):
         self.azimuth_maxspeed = 1.5
         self.azimuth_accel = 0.75
         self.azimuth_decel = 0.75
-        self.azimuth_freerange = 0.
-        self.settle_time = 1.0
+        self.azimuth_freerange = 4.
+        self.settle_time = 0.

--- a/python/lsst/sims/ocs/configuration/instrument/optics_loop_corr.py
+++ b/python/lsst/sims/ocs/configuration/instrument/optics_loop_corr.py
@@ -21,7 +21,7 @@ class OpticsLoopCorr(pexConfig.Config):
         """
         self.tel_optics_ol_slope = 1.0 / 3.5
         self.tel_optics_cl_alt_limit = [0.0, 9.0, 90.0]
-        self.tel_optics_cl_delay = [0.0, 20.0]
+        self.tel_optics_cl_delay = [0.0, 36.0]
 
     def set_array(self, conf, param):
         """Set a DDS topic array parameter.

--- a/python/lsst/sims/ocs/configuration/instrument/rotator.py
+++ b/python/lsst/sims/ocs/configuration/instrument/rotator.py
@@ -20,7 +20,7 @@ class Rotator(pexConfig.Config):
                                    'rotator was placed in filter change position. If the flag is False, '
                                    'then the rotator is left in the filter change position.', bool)
 
-    # Kinemtatic parameters
+    # Kinematatic parameters
     maxspeed = pexConfig.Field('Maximum speed (units=degrees/second) of rotator movement.', float)
     accel = pexConfig.Field('Maximum acceleration (units=degrees/second**2) of rotator movement.', float)
     decel = pexConfig.Field('Maximum deceleration (units=degrees/second**2) of rotator movement.', float)
@@ -31,8 +31,8 @@ class Rotator(pexConfig.Config):
         self.minpos = -90.0
         self.maxpos = 90.0
         self.filter_change_pos = 0.0
-        self.follow_sky = False
-        self.resume_angle = False
+        self.follow_sky = True
+        self.resume_angle = True
         self.maxspeed = 3.5
         self.accel = 1.0
         self.decel = 1.0

--- a/python/lsst/sims/ocs/configuration/science/deep_drilling_cosmology1.py
+++ b/python/lsst/sims/ocs/configuration/science/deep_drilling_cosmology1.py
@@ -80,7 +80,8 @@ class DeepDrillingCosmology1(Sequence):
         self.scheduling.max_num_targets = 100
         self.scheduling.accept_serendipity = False
         self.scheduling.accept_consecutive_visits = True
-        self.scheduling.airmass_bonus = 0.5
+        self.scheduling.airmass_bonus = 0.
+        self.scheduling.hour_angle_bonus = 0.3
 
         # --------------------------
         # Band Filter specifications

--- a/python/lsst/sims/ocs/configuration/science/galactic_plane.py
+++ b/python/lsst/sims/ocs/configuration/science/galactic_plane.py
@@ -55,7 +55,9 @@ class GalacticPlane(General):
         self.scheduling.max_num_targets = 100
         self.scheduling.accept_serendipity = False
         self.scheduling.accept_consecutive_visits = False
-        self.scheduling.airmass_bonus = 0.5
+        self.scheduling.airmass_bonus = 0.
+        self.scheduling.hour_angle_bonus = 0.3
+        self.scheduling.hour_angle_max = 3.0
 
         # --------------------------
         # Band Filter specifications

--- a/python/lsst/sims/ocs/configuration/science/north_ecliptic_spur.py
+++ b/python/lsst/sims/ocs/configuration/science/north_ecliptic_spur.py
@@ -61,7 +61,9 @@ class NorthEclipticSpur(General):
         self.scheduling.max_num_targets = 100
         self.scheduling.accept_serendipity = False
         self.scheduling.accept_consecutive_visits = False
-        self.scheduling.airmass_bonus = 0.5
+        self.scheduling.airmass_bonus = 0.
+        self.scheduling.hour_angle_bonus = 0.3
+        self.scheduling.hour_angle_max = 3.0
         self.scheduling.time_interval = 30 * 60
         self.scheduling.time_window_start = 0.5
         self.scheduling.time_window_max = 1.0

--- a/python/lsst/sims/ocs/configuration/science/south_celestial_pole.py
+++ b/python/lsst/sims/ocs/configuration/science/south_celestial_pole.py
@@ -63,7 +63,9 @@ class SouthCelestialPole(General):
         self.scheduling.max_num_targets = 100
         self.scheduling.accept_serendipity = False
         self.scheduling.accept_consecutive_visits = False
-        self.scheduling.airmass_bonus = 0.5
+        self.scheduling.airmass_bonus = 0.
+        self.scheduling.hour_angle_bonus = 0.3
+        self.scheduling.hour_angle_max = 3.0
 
         # --------------------------
         # Band Filter specifications

--- a/python/lsst/sims/ocs/configuration/science/wide_fast_deep.py
+++ b/python/lsst/sims/ocs/configuration/science/wide_fast_deep.py
@@ -63,7 +63,9 @@ class WideFastDeep(General):
         self.scheduling.max_num_targets = 500
         self.scheduling.accept_serendipity = False
         self.scheduling.accept_consecutive_visits = False
-        self.scheduling.airmass_bonus = 0.5
+        self.scheduling.airmass_bonus = 0.
+        self.scheduling.hour_angle_bonus = 0.3
+        self.scheduling.hour_angle_max = 3.0
         self.scheduling.time_interval = 30 * 60
         self.scheduling.time_window_start = 0.5
         self.scheduling.time_window_max = 1.0


### PR DESCRIPTION
Update default configuration to match that of baseline2018 with new optics closed loop delay, dome crawling and rotator set to enable values chosen by the scheduler.