### PR TITLE
point to ProposalDriver rather than generic driver

### DIFF
--- a/python/lsst/sims/ocs/kernel/simulator.py
+++ b/python/lsst/sims/ocs/kernel/simulator.py
@@ -481,7 +481,6 @@ class Simulator(object):
         """
         proposals = []
         prop_count = 0
-
         for i, general in enumerate(self.conf_comm.survey_topology['general']):
             proposals.append(write_proposal(ProposalInfo(i+1, general, "General"),
                                             self.db.session_id))
@@ -653,6 +652,8 @@ class Simulator(object):
 
         survey_topology = self.driver.configure_scheduler(config=self.conf,
                                                           config_path=self.config_path)
+
+        self.log.debug('%s', survey_topology)
 
         if survey_topology is not None:
             self.conf_comm.num_proposals = survey_topology.num_props

--- a/scripts/opsim4
+++ b/scripts/opsim4
@@ -90,7 +90,7 @@ def main(args):
             if str(args.scheduler_type) == "feature":
                 from lsst.sims.featureScheduler.driver.constants import RUN_SCRIPT
             elif str(args.scheduler_type) == "proposal":
-                from lsst.ts.scheduler.kernel.constants import RUN_SCRIPT
+                from lsst.ts.proposalScheduler.constants import RUN_SCRIPT
 
             # Get scheduler version number
             output = sp.Popen([RUN_SCRIPT, "--version"], stdout=sp.PIPE, stderr=sp.PIPE).communicate()
@@ -115,7 +115,7 @@ def main(args):
                 from lsst.sims.featureScheduler.driver import FeatureSchedulerDriver as Driver
             elif str(args.scheduler_type) == "proposal":
                 logging.info('Loading %s driver' % args.scheduler_type)
-                from lsst.ts.scheduler import Driver
+                from lsst.ts.proposalScheduler import ProposalDriver as Driver
             driver = Driver()
 
         sim = Simulator(args, db, driver=driver)


### PR DESCRIPTION
adds support for running the proposal scheduler as its own module rather than as part of ts_scheduler.