### PR TITLE
add the note column to SummaryAllProps

### DIFF
--- a/python/lsst/sims/ocs/database/tables/view_tables.py
+++ b/python/lsst/sims/ocs/database/tables/view_tables.py
@@ -65,7 +65,8 @@ def create_summary_all_props(metadata, oh, sh, sfs, p, ph, f):
                                 oh.c.moonPhase.label('moonPhase'),
                                 oh.c.sunAlt.label('sunAlt'),
                                 oh.c.sunAz.label('sunAz'),
-                                oh.c.solarElong.label('solarElong')
+                                oh.c.solarElong.label('solarElong'),
+                                oh.c.note.label('note')
                                 ]).
                         where(oh.c.observationId == sh.c.ObsHistory_observationId).
                         where(sh.c.slewCount == sfs.c.SlewHistory_slewCount).


### PR DESCRIPTION
Copy over the scheduler "note" string to the SummaryAllProps view. Should make it easier to use MAF when there's feature_based scheduler output.